### PR TITLE
feat: 회원가입 + 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,24 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.2'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/Palette/PaletteApplication.java
+++ b/src/main/java/com/umc/Palette/PaletteApplication.java
@@ -1,15 +1,41 @@
 package com.umc.Palette;
 
+import com.umc.Palette.domain.user.Role;
+import com.umc.Palette.domain.user.domain.User;
+import com.umc.Palette.domain.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @EnableJpaAuditing
 @SpringBootApplication
-public class PaletteApplication {
+public class PaletteApplication implements CommandLineRunner {
+
+	@Autowired
+	private UserRepository userRepository;
 
 	public static void main(String[] args) {
 		SpringApplication.run(PaletteApplication.class, args);
+	}
+
+
+	public void run(String... args) {
+		User adminAccount = userRepository.findByRole(Role.ROLE_ADMIN);
+		if (null == adminAccount) {
+			User user = new User();
+
+			user.setEmail("admin@gmail.com");
+			user.setName("admin");
+			user.setNickname("admin");
+			user.setLoginId("ad");
+			user.setRole(Role.ROLE_ADMIN);
+			user.setPassword(new BCryptPasswordEncoder().encode("admin"));
+			user.setIntroduction("I am admin");
+			userRepository.save(user);
+		}
 	}
 
 }

--- a/src/main/java/com/umc/Palette/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/Palette/config/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.umc.Palette.config;
+
+import com.umc.Palette.domain.user.service.JwtService;
+import com.umc.Palette.domain.user.service.UserService;
+import io.micrometer.common.util.StringUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String userLoginId;
+
+        if(StringUtils.isEmpty(authHeader) || !org.apache.commons.lang3.StringUtils.startsWith(authHeader, "Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        jwt = authHeader.substring( 7);
+        userLoginId = jwtService.extractUserName(jwt);
+
+        if(StringUtils.isNotEmpty(userLoginId) && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userService.userDetailsService().loadUserByUsername(userLoginId);
+
+            if(jwtService.isTokenValid(jwt, userDetails)) {
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+                UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()
+                );
+                token.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                securityContext.setAuthentication(token);
+                SecurityContextHolder.setContext(securityContext );
+            }
+        }
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/src/main/java/com/umc/Palette/config/SecurityConfiguration.java
+++ b/src/main/java/com/umc/Palette/config/SecurityConfiguration.java
@@ -1,0 +1,65 @@
+package com.umc.Palette.config;
+
+import com.umc.Palette.domain.user.Role;
+import com.umc.Palette.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private final UserService userService;
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(request -> request.requestMatchers("/api/v1/auth/**")
+                        .permitAll()
+                        .requestMatchers("/api/v1/admin").hasAnyAuthority(Role.ROLE_ADMIN.name())
+                        .requestMatchers("/api/v1/user").hasAnyAuthority(Role.ROLE_USER.name())
+                        .requestMatchers("/api/vi/no_user").hasAnyAuthority(Role.ROEL_NO_USER.name())
+                        .anyRequest().authenticated())
+
+                .sessionManagement(manager -> manager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider()).addFilterBefore(
+                        jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class
+                );
+                return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userService.userDetailsService());
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+        return authenticationProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/follow/domain/Follow.java
+++ b/src/main/java/com/umc/Palette/domain/follow/domain/Follow.java
@@ -3,10 +3,6 @@ package com.umc.Palette.domain.follow.domain;
 import com.umc.Palette.domain.base_time.BaseTimeEntity;
 import com.umc.Palette.domain.user.domain.User;
 import jakarta.persistence.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.sql.Timestamp;
 
 @Entity
 public class Follow extends BaseTimeEntity {

--- a/src/main/java/com/umc/Palette/domain/mail/controller/MailController.java
+++ b/src/main/java/com/umc/Palette/domain/mail/controller/MailController.java
@@ -1,0 +1,54 @@
+package com.umc.Palette.domain.mail.controller;
+
+import com.umc.Palette.domain.mail.dto.EmailAuthRequest;
+import com.umc.Palette.domain.mail.dto.EmailCheckRequest;
+import com.umc.Palette.domain.mail.service.EmailService;
+import com.umc.Palette.domain.mail.service.EmailServiceImpl;
+import com.umc.Palette.global.exception.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static com.umc.Palette.global.exception.BaseResponseStatus.*;
+
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+
+public class MailController {
+
+    private final EmailService emailService;
+
+    private final BaseResponseService baseResponseService;
+
+    private final CustomExceptionHandler customExceptionHandler;
+
+
+    // 회원가입 - (3) 유저 이메일로 인증번호 전송
+    @PostMapping("/signup/emailCheck")
+    public BaseResponse<Object> emailConfirm(@RequestBody EmailCheckRequest emailCheckRequest) {
+        String confirm;
+        try {
+            confirm = emailService.sendSimpleMessage(emailCheckRequest.getEmail());
+        } catch (BaseException e){
+            return baseResponseService.getFailureResponse(UNABLE_TO_SEND_EMAIL);
+        }
+        catch (Exception e) {
+            return customExceptionHandler.handleGeneralException(e).getBody();
+        }
+        return new BaseResponse<>(true,"인증번호 값 전송" ,2002 ,confirm);
+
+    }
+
+    // 회원가입 - (4) 유저가 받은 인증번호 일치 확인
+    @PostMapping("/signup/emailAuthentication")
+    public BaseResponse<Object> ememailAuthentication(@RequestBody EmailAuthRequest emailAuthRequest) {
+        try {
+            return emailAuthRequest.getCertificationNum().equals(EmailServiceImpl.ePw)
+                    ? baseResponseService.getSuccessResponse(EQUAL_CERTIFICATION_NUM)
+                    : baseResponseService.getFailureResponse(NOT_EQUAL_CERTIFICATION_NUM);
+        } catch (Exception e) {
+            return customExceptionHandler.handleGeneralException(e).getBody();
+        }
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/mail/domain/EmailConfig.java
+++ b/src/main/java/com/umc/Palette/domain/mail/domain/EmailConfig.java
@@ -1,0 +1,59 @@
+package com.umc.Palette.domain.mail.domain;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+
+@Configuration
+@PropertySource("classpath:application.properties")
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties()
+    {
+        Properties pt = new Properties();
+        pt.put("mail.smtp.auth", auth);
+        pt.put("mail.smtp.starttls.enable", starttlsEnable);
+        pt.put("mail.smtp.starttls.required", starttlsRequired);
+
+        return pt;
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/mail/dto/EmailAuthRequest.java
+++ b/src/main/java/com/umc/Palette/domain/mail/dto/EmailAuthRequest.java
@@ -1,0 +1,8 @@
+package com.umc.Palette.domain.mail.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailAuthRequest {
+    private String certificationNum;
+}

--- a/src/main/java/com/umc/Palette/domain/mail/dto/EmailCheckRequest.java
+++ b/src/main/java/com/umc/Palette/domain/mail/dto/EmailCheckRequest.java
@@ -1,0 +1,8 @@
+package com.umc.Palette.domain.mail.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailCheckRequest {
+    private String email;
+}

--- a/src/main/java/com/umc/Palette/domain/mail/service/EmailService.java
+++ b/src/main/java/com/umc/Palette/domain/mail/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.umc.Palette.domain.mail.service;
+
+public interface EmailService {
+    String sendSimpleMessage(String to)throws Exception;
+}

--- a/src/main/java/com/umc/Palette/domain/mail/service/EmailServiceImpl.java
+++ b/src/main/java/com/umc/Palette/domain/mail/service/EmailServiceImpl.java
@@ -1,0 +1,97 @@
+package com.umc.Palette.domain.mail.service;
+
+import java.util.Random;
+
+//import javax.mail.Message.RecipientType;
+//import javax.mail.internet.InternetAddress;
+//import javax.mail.internet.MimeMessage;
+
+import com.umc.Palette.domain.mail.service.EmailService;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+
+//    // 인증번호
+//    private String certificationNum;
+
+
+    @Autowired
+    JavaMailSender emailSender;
+
+    public static final String ePw = createKey();
+
+    private MimeMessage createMessage(String to)throws Exception{
+        System.out.println("보내는 대상 : "+ to);
+        System.out.println("인증 번호 : "+ePw);
+        MimeMessage  message = emailSender.createMimeMessage();
+        System.out.println("1");
+        ((MimeMessage) message).addRecipients(MimeMessage.RecipientType.TO, to);//보내는 대상
+        message.setSubject("이메일 인증 테스트");//제목
+
+        String msgg="";
+        msgg+= "<div style='margin:15px;'>";
+        msgg+= "<h1> Rhythm Palette. </h1>";
+        msgg+= "<br>";
+        msgg+= "<p>아래 코드를 복사해 입력해주세요<p>";
+        msgg+= "<br>";
+        msgg+= "<p>감사합니다.<p>";
+        msgg+= "<br>";
+        msgg+= "<div align='center' style='border:1px solid black; font-family:verdana';>";
+        msgg+= "<h3 style='color:blue;'>이메일 인증 코드입니다.</h3>";
+        msgg+= "<div style='font-size:130%'>";
+        msgg+= "CODE : <strong>";
+        msgg+= ePw+"</strong><div><br/> ";
+        msgg+= "</div>";
+        message.setText(msgg, "utf-8", "html");//내용
+        message.setFrom(new InternetAddress("rhythmpal0219@gmail.com","hyun"));//보내는 사람
+
+        System.out.println("2");
+        return message;
+    }
+
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random rnd = new Random();
+
+        for (int i = 0; i < 8; i++) { // 인증코드 8자리
+            int index = rnd.nextInt(3); // 0~2 까지 랜덤
+
+            switch (index) {
+                case 0:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 97));
+                    //  a~z  (ex. 1+97=98 => (char)98 = 'b')
+                    break;
+                case 1:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 65));
+                    //  A~Z
+                    break;
+                case 2:
+                    key.append((rnd.nextInt(10)));
+                    // 0~9
+                    break;
+            }
+        }
+        return key.toString();
+    }
+    @Override
+    public String sendSimpleMessage(String to)throws Exception {
+        // TODO Auto-generated method stub
+        MimeMessage message = createMessage(to);
+        try{//예외처리
+            System.out.println("3");
+            emailSender.send(message);
+            System.out.println("4");
+        }catch(MailException es){
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+        System.out.println("5");
+        return ePw;
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/user/Role.java
+++ b/src/main/java/com/umc/Palette/domain/user/Role.java
@@ -1,0 +1,6 @@
+package com.umc.Palette.domain.user;
+
+public enum Role {
+    ROEL_NO_USER, ROLE_USER, ROLE_ADMIN
+    // 비회원, 회원, 관리자
+}

--- a/src/main/java/com/umc/Palette/domain/user/controller/AdminController.java
+++ b/src/main/java/com/umc/Palette/domain/user/controller/AdminController.java
@@ -1,0 +1,18 @@
+package com.umc.Palette.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    @GetMapping
+    public ResponseEntity<String> sayHello() {
+        return ResponseEntity.ok("Hi Admin");
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/user/controller/AuthenticationController.java
+++ b/src/main/java/com/umc/Palette/domain/user/controller/AuthenticationController.java
@@ -1,0 +1,87 @@
+package com.umc.Palette.domain.user.controller;
+
+import com.umc.Palette.domain.user.dto.*;
+import com.umc.Palette.domain.user.service.AuthenticationService;
+import com.umc.Palette.global.exception.*;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.umc.Palette.global.exception.BaseResponseStatus.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    private final BaseResponseService baseResponseService;
+
+    private final CustomExceptionHandler customExceptionHandler;
+
+    // 회원가입 - (1) 아이디 중복 확인
+    @GetMapping("signup/{loginId}")
+    public BaseResponse<Object> checkLoginIdDuplicate(@PathVariable(name = "loginId") String loginId) {
+        try {
+            return authenticationService.checkLoginIdDuplicate(loginId)
+                    ? baseResponseService.getFailureResponse(ALREADY_EXISTS)
+                    : baseResponseService.getSuccessResponse(NOT_EXISTS_LOGIN_ID);
+        } catch (Exception e) {
+            return customExceptionHandler.handleGeneralException(e).getBody();
+        }
+    }
+
+    // 회원가입 - (2) 비밀번호 조건 확인
+    @PostMapping("/signup/passwordCheck")
+    public BaseResponse<Object> passwordCheck(@RequestBody PasswordCheckRequest passwordCheckRequest) {
+        try {
+            return authenticationService.passwordCheck(passwordCheckRequest.getFirstPassword(), passwordCheckRequest.getSecondPassword())
+                    ? baseResponseService.getSuccessResponse(SATISFIED_PW_CRITERIA)
+                    : baseResponseService.getFailureResponse(NOT_SATISFIED_PW_CRITERIA);
+        } catch (ConstraintViolationException e) {
+            return baseResponseService.getFailureResponse(NOT_SATISFIED_PW_CRITERIA);
+        } catch (Exception e){
+            return customExceptionHandler.handleGeneralException(e).getBody();
+        }
+    }
+
+    /**
+     *  회원가입 - (3) 이메일 인증 확인 (MailController에서 진행)
+     *  회원가입 - (4) 유저가 받은 인증번호 일치 확인 (MailController에서 진행)
+     */
+
+    // 회원가입 - (5) 최종 회원가입 완료
+    @PostMapping("/signup")
+    public BaseResponse<Object> signup(@RequestBody SignUpRequest signUpRequest) {
+        try{
+            authenticationService.signup(signUpRequest);
+        } catch(ConstraintViolationException e) {
+            return baseResponseService.getFailureResponse(NOT_SATISFIED_PW_CRITERIA);
+        } catch (Exception e) {
+            return baseResponseService.getSuccessResponse(NOT_EQUAL_PW);
+        }
+        return baseResponseService.getSuccessResponse(SIGN_UP_COMPLETE);
+
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<JwtAuthenticationResponse> signin(@RequestBody SigninRequest signinRequest) {
+        return ResponseEntity.ok(authenticationService.signin(signinRequest));
+
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtAuthenticationResponse> refresh(@RequestBody RefreshTokenRequest refreshTokenRequest) {
+        return ResponseEntity.ok(authenticationService.refreshToken(refreshTokenRequest));
+
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/umc/Palette/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/Palette/domain/user/controller/UserController.java
@@ -1,0 +1,20 @@
+package com.umc.Palette.domain.user.controller;
+
+import com.umc.Palette.domain.user.service.UserService;
+import com.umc.Palette.global.exception.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+    UserService userService;
+
+    @GetMapping("/{userName}")
+    public BaseResponse<Object> hi(@PathVariable(name = "userName") String userName) {
+        return new BaseResponse<>(true, "안녕하세요", 2005, userName);
+    }
+
+}

--- a/src/main/java/com/umc/Palette/domain/user/domain/User.java
+++ b/src/main/java/com/umc/Palette/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.umc.Palette.domain.user.domain;
 
+
 import com.umc.Palette.domain.base_time.BaseTimeEntity;
 import com.umc.Palette.domain.comment.domain.Comment;
 import com.umc.Palette.domain.comment.domain.UserCommentLike;
@@ -8,13 +9,23 @@ import com.umc.Palette.domain.music.domain.Music;
 import com.umc.Palette.domain.post.domain.Post;
 import com.umc.Palette.domain.post.domain.PostLike;
 import com.umc.Palette.domain.preference_genre.domain.PreferenceGenre;
+import com.umc.Palette.domain.user.Role;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-
+@EqualsAndHashCode(callSuper = true)
+@Data
 @Entity
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -32,16 +43,20 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false)    // 회원가입 후 입력 (필수)
     private String nickname;
 
-    private String introduction;
+    @Column(nullable = false)
+    private String introduction;    // 회원가입 후 입력 (필수)
 
-    @Column(length = 1, nullable = false)
+    @Column(length = 1, nullable = true)    // 선택 사항
     private Character gender;
 
-    @Column(nullable = false)
+    @Column(nullable = true)    // 선택사항
     private LocalDate birth;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;    // 권한
 
     @OneToMany(mappedBy = "followerId")
     private List<Follow> followerList = new ArrayList<>();
@@ -71,4 +86,45 @@ public class User extends BaseTimeEntity {
 
     public User(){}
 
+//    @Builder
+//    public User(String loginId, String password, Role role) {
+//        this.loginId = loginId;
+//        this.password = password;
+//        this.role = role;
+//    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/umc/Palette/domain/user/dto/JwtAuthenticationResponse.java
+++ b/src/main/java/com/umc/Palette/domain/user/dto/JwtAuthenticationResponse.java
@@ -1,0 +1,11 @@
+package com.umc.Palette.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class JwtAuthenticationResponse {
+
+    private String token;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/umc/Palette/domain/user/dto/PasswordCheckRequest.java
+++ b/src/main/java/com/umc/Palette/domain/user/dto/PasswordCheckRequest.java
@@ -1,0 +1,9 @@
+package com.umc.Palette.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class PasswordCheckRequest {
+    private String firstPassword;
+    private String secondPassword;
+}

--- a/src/main/java/com/umc/Palette/domain/user/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/umc/Palette/domain/user/dto/RefreshTokenRequest.java
@@ -1,0 +1,9 @@
+package com.umc.Palette.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+
+    private String token;
+}

--- a/src/main/java/com/umc/Palette/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/com/umc/Palette/domain/user/dto/SignUpRequest.java
@@ -1,0 +1,14 @@
+package com.umc.Palette.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class SignUpRequest {
+
+    private String name;
+    private String loginId;
+    private String email;
+    private String password;
+    private String nickname;
+    private String introduction;
+}

--- a/src/main/java/com/umc/Palette/domain/user/dto/SigninRequest.java
+++ b/src/main/java/com/umc/Palette/domain/user/dto/SigninRequest.java
@@ -1,0 +1,10 @@
+package com.umc.Palette.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class SigninRequest {
+
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/com/umc/Palette/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/Palette/domain/user/repository/UserRepository.java
@@ -1,9 +1,17 @@
 package com.umc.Palette.domain.user.repository;
 
+import com.umc.Palette.domain.user.Role;
 import com.umc.Palette.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByLoginId(String loginId);
+    Optional<User> findByLoginId(String loginId); // jwt에서 사용
+
+    User findByRole(Role role);
+
 }

--- a/src/main/java/com/umc/Palette/domain/user/service/AuthenticationService.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/AuthenticationService.java
@@ -1,0 +1,18 @@
+package com.umc.Palette.domain.user.service;
+
+import com.umc.Palette.domain.user.domain.User;
+import com.umc.Palette.domain.user.dto.*;
+
+public interface AuthenticationService {
+
+    User signup(SignUpRequest signUpRequest);
+
+    JwtAuthenticationResponse signin(SigninRequest signinRequest);
+
+    JwtAuthenticationResponse refreshToken(RefreshTokenRequest refreshTokenRequest);
+
+    Boolean checkLoginIdDuplicate(String loginId);
+
+    boolean passwordCheck(String pw1, String pw2);
+
+}

--- a/src/main/java/com/umc/Palette/domain/user/service/JwtService.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/JwtService.java
@@ -1,0 +1,16 @@
+package com.umc.Palette.domain.user.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Map;
+
+public interface JwtService {
+
+    String extractUserName(String token);
+
+    String generateToken(UserDetails userDetails);
+
+    boolean isTokenValid(String token, UserDetails userDetails);
+
+    String generateRefreshToken(Map<String, Object> extraClaims, UserDetails userDetails);
+}

--- a/src/main/java/com/umc/Palette/domain/user/service/UserService.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/UserService.java
@@ -1,0 +1,12 @@
+package com.umc.Palette.domain.user.service;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserService {
+
+    UserDetailsService userDetailsService();
+
+//    String checkLoginIdDuplicate(String loginId);
+
+
+}
+

--- a/src/main/java/com/umc/Palette/domain/user/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/impl/AuthenticationServiceImpl.java
@@ -1,0 +1,121 @@
+package com.umc.Palette.domain.user.service.impl;
+
+import com.umc.Palette.domain.user.Role;
+import com.umc.Palette.domain.user.domain.User;
+import com.umc.Palette.domain.user.dto.JwtAuthenticationResponse;
+import com.umc.Palette.domain.user.dto.RefreshTokenRequest;
+import com.umc.Palette.domain.user.dto.SignUpRequest;
+import com.umc.Palette.domain.user.dto.SigninRequest;
+import com.umc.Palette.domain.user.repository.UserRepository;
+import com.umc.Palette.domain.user.service.AuthenticationService;
+import com.umc.Palette.domain.user.service.JwtService;
+import com.umc.Palette.global.exception.BaseResponse;
+import com.umc.Palette.global.exception.BaseResponseService;
+import com.umc.Palette.global.exception.BaseResponseStatus;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthenticationServiceImpl implements AuthenticationService {
+
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final AuthenticationManager authenticationManager;
+
+    private final JwtService jwtService;
+
+    private final BaseResponseService baseResponseService;
+
+    public User signup(SignUpRequest signUpRequest) {
+
+        User user = new User();
+
+        user.setEmail(signUpRequest.getEmail());
+        user.setName(signUpRequest.getName());
+        user.setRole(Role.ROLE_USER);
+        System.out.println("사용자 패스워드 미리보기: "+ signUpRequest.getPassword());
+
+        // 제약 검증
+        if (!signUpRequest.getPassword().matches("(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}")) {
+            // 제약 조건을 만족하지 않는 경우
+            throw new ConstraintViolationException("비밀번호 제약을 만족하지 않습니다.", null);
+//            return baseResponseService.getFailureResponse(BaseResponseStatus.NOT_SATISFIED_PW_CRITERIA);
+        } else {
+            // 제약이 충족된 경우 비밀번호 암호화
+            user.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
+        }
+
+        user.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
+        user.setNickname(signUpRequest.getNickname());  // 잠시 추가
+        user.setIntroduction(signUpRequest.getIntroduction());  // 잠시 추가
+        user.setLoginId(signUpRequest.getLoginId());
+
+        return userRepository.save(user);
+
+    }
+
+    public JwtAuthenticationResponse signin(SigninRequest signinRequest) {
+
+        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(signinRequest.getLoginId(),
+                signinRequest.getPassword()));
+
+        var user = userRepository.findByLoginId(signinRequest.getLoginId()).orElseThrow(() -> new IllegalArgumentException("Invalid login_Id or password"));
+        var jwt = jwtService.generateToken(user);
+        var refreshToken = jwtService.generateRefreshToken(new HashMap<>(), user);
+
+        JwtAuthenticationResponse jwtAuthenticationResponse = new JwtAuthenticationResponse();
+
+        jwtAuthenticationResponse.setToken(jwt);
+        jwtAuthenticationResponse.setRefreshToken(refreshToken);
+        return jwtAuthenticationResponse;
+
+    }
+
+    public JwtAuthenticationResponse refreshToken(RefreshTokenRequest refreshTokenRequest) {
+        String userLoginId = jwtService.extractUserName(refreshTokenRequest.getToken());
+        User user = userRepository.findByLoginId(userLoginId).orElseThrow();
+
+        if(jwtService.isTokenValid(refreshTokenRequest.getToken(), user)) {
+            var jwt = jwtService.generateToken(user);
+
+            JwtAuthenticationResponse jwtAuthenticationResponse = new JwtAuthenticationResponse();
+
+            jwtAuthenticationResponse.setToken(jwt);
+            jwtAuthenticationResponse.setRefreshToken(refreshTokenRequest.getToken() );
+            return jwtAuthenticationResponse;
+        }
+        return null;
+    }
+
+    public Boolean checkLoginIdDuplicate(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
+
+
+    public boolean passwordCheck(String firstpassword, String secondpassword) {
+        // 제약 검증
+        if (!firstpassword.matches("(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}")) {
+            // 제약 조건을 만족하지 않는 경우
+            throw new ConstraintViolationException("비밀번호 제약을 만족하지 않습니다.", null);
+        }
+
+        if (firstpassword.equals(secondpassword)){
+            return true;
+        }
+        else
+            return false;
+    }
+}

--- a/src/main/java/com/umc/Palette/domain/user/service/impl/JwtServiceImpl.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/impl/JwtServiceImpl.java
@@ -1,0 +1,69 @@
+package com.umc.Palette.domain.user.service.impl;
+
+import com.umc.Palette.domain.user.service.JwtService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.cglib.core.internal.Function;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class JwtServiceImpl implements JwtService {
+
+
+    public String generateToken(UserDetails userDetails) {
+        return Jwts.builder().setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24))
+                .signWith(getSiginKey(),  SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        return Jwts.builder().setClaims(extraClaims).setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 604800000))
+                .signWith(getSiginKey(),  SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+
+    public String extractUserName(String token) {
+        return extractClaim(token, Claims::getSubject);
+
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimsResolvers) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolvers.apply(claims);
+    }
+
+    private Key getSiginKey(){
+        byte[] key = Decoders.BASE64.decode("2bf4573b548695f78d20191551c4bee3e6ebd71059dd4be96fd410ce3669afad");
+        return Keys.hmacShaKeyFor(key);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(getSiginKey()).build().parseClaimsJws(token).getBody();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUserName(token);
+        return(username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractClaim(token, Claims::getExpiration).before(new Date());
+    }
+
+}

--- a/src/main/java/com/umc/Palette/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/umc/Palette/domain/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,38 @@
+package com.umc.Palette.domain.user.service.impl;
+
+import com.umc.Palette.domain.user.repository.UserRepository;
+import com.umc.Palette.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetailsService userDetailsService() {
+        return new UserDetailsService() {
+            @Override
+            public UserDetails loadUserByUsername(String username) {
+                return userRepository.findByLoginId(username)
+                        .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            }
+        };
+
+    }
+
+//    @Override
+//    public String checkLoginIdDuplicate(String loginId) {
+//        return userRepository.existsByLoginId(loginId);
+//    }
+
+//    public boolean checkLoginIdDuplicate(String loginId) {
+//        return userRepository.existsByLoginId(loginId);
+//    }
+
+}

--- a/src/main/java/com/umc/Palette/global/exception/BaseException.java
+++ b/src/main/java/com/umc/Palette/global/exception/BaseException.java
@@ -3,11 +3,15 @@ import lombok.*;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
+//@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class BaseException extends Exception {
 
     public BaseResponseStatus status;
+
+    public BaseException(BaseResponseStatus status) {
+        super(status.getMessage());
+    }
 }
 
 

--- a/src/main/java/com/umc/Palette/global/exception/BaseResponse.java
+++ b/src/main/java/com/umc/Palette/global/exception/BaseResponse.java
@@ -13,6 +13,14 @@ public class BaseResponse<T> {
     private int code; // 코드
     private T data; // 전달 데이터
 
+    // data 타입을 String으로 바꾼 생성자
+    public BaseResponse(boolean isSuccess, String message, int code, String data) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+        this.code = code;
+        this.data = (T) data;
+    }
+
     @Builder
     public BaseResponse(boolean isSuccess, String message, int code, T data) {
         this.isSuccess = isSuccess;

--- a/src/main/java/com/umc/Palette/global/exception/BaseResponseService.java
+++ b/src/main/java/com/umc/Palette/global/exception/BaseResponseService.java
@@ -19,6 +19,8 @@ public interface BaseResponseService {
      */
     <T> BaseResponse<Object> getSuccessResponse();
 
+    <T>  BaseResponse<Object> getSuccessResponse(BaseResponseStatus status);
+
     /**
      * 실패 응답 메서드
      *

--- a/src/main/java/com/umc/Palette/global/exception/BaseResponseServiceImpl.java
+++ b/src/main/java/com/umc/Palette/global/exception/BaseResponseServiceImpl.java
@@ -35,6 +35,16 @@ public class BaseResponseServiceImpl implements BaseResponseService {
                 .build();
     }
 
+    public <T> BaseResponse<Object> getSuccessResponse(BaseResponseStatus status) {
+        return BaseResponse.builder()
+                .isSuccess(status.isSuccess())
+                .code(status.getCode())
+                .message(status.getMessage())
+                .build();
+    }
+
+
+
     /**
      * 실패 응답 메서드
      *

--- a/src/main/java/com/umc/Palette/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/umc/Palette/global/exception/BaseResponseStatus.java
@@ -7,6 +7,17 @@ public enum BaseResponseStatus {
 
     // -------- 성공 코드 시작 -------- //
     SUCCESS(true, 1000, "요청에 성공했습니다."),
+    NOT_EXISTS_LOGIN_ID(true, 2000, "해당 아이디를 사용할 수 있습니다."),
+    SATISFIED_PW_CRITERIA(true, 2001, "비밀번호가 확인되었습니다."),
+
+    SEND_EMAIL(true, 2002, "인증번호를 전송했습니다."),
+    // MainController[회원가입(3)]에서 2002번 status 생성하여 사용, code 겹치지 않기 위해 작성
+
+    EQUAL_CERTIFICATION_NUM(true, 2003, "인증번호가 일치합니다."),
+    SIGN_UP_COMPLETE(true, 2004, "회원가입을 완료하였습니다."),
+
+
+
     // -------- 성공 코드 종료 -------- //
 
 
@@ -17,11 +28,17 @@ public enum BaseResponseStatus {
      * User
      * Code : 2000
      */
-    INVALID_PASSWORD(false, 2000, "아이디 또는 비밀번호가 틀렸습니다."),
-    ALREADY_EXISTS(false, 20001, "아이디가 이미 존재합니다."),
-    ENTITY_NOT_FOUND(false, 2002,"entity not found"),
-    USER_NOT_FOUND(false, 2003, "해당하는 유저 정보가 없습니다."),
-    EMPTY_TOKEN(false, 2004, "토큰을 확인해주세요."),
+    ALREADY_EXISTS(false, 2100, "아이디가 이미 존재합니다."),
+    NOT_EQUAL_PW(false, 2101, "비밀번호가 일치하지 않습니다."),
+    NOT_SATISFIED_PW_CRITERIA(false, 2102, "영어(대/소문), 숫자, 특수문자를 포함해주세요."),
+
+    UNABLE_TO_SEND_EMAIL(false, 2103, "이메일 전송에 실패하였습니다."),
+    NOT_EQUAL_CERTIFICATION_NUM(false, 2104, "인증번호가 일치하지 않습니다."),
+
+    INVALID_PASSWORD(false, 2002, "아이디 또는 비밀번호가 틀렸습니다."),
+    ENTITY_NOT_FOUND(false, 2004,"entity not found"),
+    USER_NOT_FOUND(false, 2005, "해당하는 유저 정보가 없습니다."),
+    EMPTY_TOKEN(false, 2006, "토큰을 확인해주세요."),
     ;
 
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔗 반영 브랜치
feature/login -> dev

### ✨ 변경 사항
User 도메인 
- 비회원, 회원, 관리자 역할 추가

회원가입 구현 
- (1) 아이디 중복 확인 기능
- (2) 비밀번호 일치 여부 확인 기능
- (3) 유저 이메일로 인증 번호 전송 기능
- (4) 유저가 입력한 인증 번호와 서버에 인증 번호 비교 기능
- (5) (1) ~(4)의 정보를 합하여 회원 가입 완료

로그인 구현
- 시큐리티 (회원가입/로그인) 적용


### ✅ 테스트 결과
- [x] 로그인 아이디 중복
- [x] 비밀번호 조건 확인
- [x] 이메일 인증번호 전송
- [x] 이메일 인증번호 일치 확인
- [x] 유저 회원가입
- [x] 유저 로그인시 token 생성
- [x] 유저는 token을 통해 api 접속